### PR TITLE
chore: tests on the actual text rank code

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -253,8 +253,10 @@ def test_add_node_matrix():
 
 def test_add_edge_list():
     graph = AdjacencyList([rand_str() for _ in range(random.randint(10, 100))])
-    source = random.randint(0, graph.vertex_count - 1)
-    target = random.randint(0, graph.vertex_count - 1)
+    source = target = 0
+    while source == target:
+        source = random.randint(0, graph.vertex_count - 1)
+        target = random.randint(0, graph.vertex_count - 1)
     weight = random.random()
 
     source_req = random.choice([source, graph[source]])
@@ -266,10 +268,24 @@ def test_add_edge_list():
     assert graph.vertices[target].edges_in[source] == weight
 
 
+def test_add_edge_greater_than_zero():
+    graph = AdjacencyList([rand_str() for _ in range(random.randint(10, 100))])
+    source = target = 0
+    while source == target:
+        source = random.randint(0, graph.vertex_count - 1)
+        target = random.randint(0, graph.vertex_count - 1)
+    weight = (random.random() + 0.01) * -1
+
+    with pytest.raises(ValueError):
+        graph.add_edge(source, target, weight)
+
+
 def test_add_edge_matrix():
     graph = AdjacencyMatrix([rand_str() for _ in range(random.randint(10, 100))])
-    source = random.randint(0, graph.vertex_count - 1)
-    target = random.randint(0, graph.vertex_count - 1)
+    source = target = 0
+    while source == target:
+        source = random.randint(0, graph.vertex_count - 1)
+        target = random.randint(0, graph.vertex_count - 1)
     weight = random.random()
 
     source_req = random.choice([source, graph[source]])
@@ -278,6 +294,18 @@ def test_add_edge_matrix():
     graph.add_edge(source_req, target_req, weight)
 
     assert graph.adjacency_matrix[source, target] == weight
+
+
+def test_add_edge_greater_than_zero():
+    graph = AdjacencyMatrix([rand_str() for _ in range(random.randint(10, 100))])
+    source = target = 0
+    while source == target:
+        source = random.randint(0, graph.vertex_count - 1)
+        target = random.randint(0, graph.vertex_count - 1)
+    weight = (random.random() + 0.01) * -1
+
+    with pytest.raises(ValueError):
+        graph.add_edge(source, target, weight)
 
 
 def test_density_half():

--- a/tests/test_text_rank.py
+++ b/tests/test_text_rank.py
@@ -1,11 +1,16 @@
 import sys
 import math
 import random
+from copy import deepcopy
+from itertools import combinations
 from unittest.mock import patch, MagicMock
 import pytest
+import numpy as np
+from text_rank.graph import AdjacencyList, AdjacencyMatrix, Vertex
 from text_rank.text_rank import (
     sum_edges,
     accumulate_score,
+    text_rank,
     text_rank_init_list,
     text_rank_init_matrix,
     text_rank_update_list,
@@ -13,6 +18,7 @@ from text_rank.text_rank import (
     text_rank_output_list,
     text_rank_output_matrix,
 )
+from utils import rand_str
 
 
 TRIALS = 100
@@ -45,25 +51,162 @@ def test_accumulate_score():
     assert math.isclose(accumulate_score(vertex, ws, denom), gold)
 
 
-def test_init_list():
-    pass
+def test_init_list_shapes():
+    graph = MagicMock(vertices=[MagicMock() for _ in range(random.randint(10, 100))])
+    ws, denom = text_rank_init_list(graph)
+    assert len(ws) == len(denom) == len(graph.vertices)
 
 
-def test_init_matrix():
-    pass
+def test_init_list_ws_inits():
+    seed = 1337
+    gold_ws = [
+        0.6177528569514706,
+        0.5332655736050008,
+        0.36584835924937553,
+        0.5857873539022715,
+        0.16568728368878083,
+        0.8243737469076314,
+        0.38370480861420864,
+        0.7896128249156874,
+        0.9217265098962596,
+        0.30763338797950246,
+    ]
+    graph = MagicMock(vertices=[MagicMock() for _ in range(len(gold_ws))])
+    ws, _ = text_rank_init_list(graph, seed=seed)
+    for w, gw in zip(ws, gold_ws):
+        assert math.isclose(w, gw)
+
+
+def test_init_list_d_norms():
+    graph = MagicMock(vertices=[MagicMock() for _ in range(random.randint(10, 100))])
+    gold = [random.random() for _ in range(len(graph.vertices))]
+    values = deepcopy(gold)
+    zero_indices = random.sample(range(len(gold)), len(gold) // 2)
+    for i in zero_indices:
+        gold[i] = 1
+        values[i] = 0
+    with patch("text_rank.text_rank_module.sum_edges") as sum_patch:
+        sum_patch.side_effect = values
+        _, denom = text_rank_init_list(graph)
+        for d, g in zip(denom, gold):
+            assert math.isclose(d, g)
+
+
+def test_init_matrix_shapes():
+    verts = random.randint(10, 100)
+    graph = MagicMock(vertex_count=verts, adjacency_matrix=np.random.rand(verts, verts))
+    ws, denom = text_rank_init_matrix(graph)
+    assert len(ws) == len(denom) == verts
+
+
+def test_init_matrix_ws_inits():
+    seed = 1337
+    gold_ws = np.array(
+        [
+            0.6177528569514706,
+            0.5332655736050008,
+            0.36584835924937553,
+            0.5857873539022715,
+            0.16568728368878083,
+            0.8243737469076314,
+            0.38370480861420864,
+            0.7896128249156874,
+            0.9217265098962596,
+            0.30763338797950246,
+        ]
+    )
+    graph = MagicMock(vertex_count=len(gold_ws), adjacency_matrix=np.random.rand(len(gold_ws), len(gold_ws)))
+    ws, _ = text_rank_init_matrix(graph, seed=seed)
+    np.testing.assert_allclose(ws, gold_ws)
+
+
+def test_init_matrix_d_norms():
+    graph = MagicMock(vertices=[MagicMock() for _ in range(random.randint(10, 100))])
+    gold = [random.random() for _ in range(len(graph.vertices))]
+    values = deepcopy(gold)
+    zero_indices = random.sample(range(len(gold)), len(gold) // 2)
+    for i in zero_indices:
+        gold[i] = 1
+        values[i] = 0
+    with patch("text_rank.text_rank_module.sum_edges") as sum_patch:
+        sum_patch.side_effect = values
+        _, denom = text_rank_init_matrix(graph)
+        for d, g in zip(denom, gold):
+            assert math.isclose(d, g)
 
 
 def test_update_list():
-    pass
+    graph = MagicMock(vertices=[MagicMock() for _ in range(random.randint(10, 100))])
+    dampening = random.random()
+    golds = [random.random() for _ in graph.vertices]
+    update_values = [(g - 1 + dampening) / dampening for g in golds]
+    with patch("text_rank.text_rank_module.accumulate_score") as acc_patch:
+        acc_patch.side_effect = update_values
+        ws = text_rank_update_list(graph, None, None, dampening)
+        for w, g in zip(ws, golds):
+            math.isclose(w, g)
 
 
 def test_update_matrix():
-    pass
+    verts = np.random.randint(10, 100)
+    ws = np.random.rand(verts)
+    adj = np.random.rand(verts, verts)
+    denom = np.random.rand(verts, 1)
+    graph = MagicMock(adjacency_matrix=adj)
+    dampening = np.random.rand()
+    gold = (1 - dampening) + dampening * np.sum(ws.reshape((-1, 1)) * (adj / denom), axis=0)
+
+    res = text_rank_update_matrix(graph, ws, denom, dampening)
+
+    np.testing.assert_allclose(res, gold)
 
 
 def test_output_list():
-    pass
+    v = random.randint(2, 10)
+    verts = [rand_str() for _ in range(v)]
+    graph = MagicMock(vertices=[Vertex(v) for v in verts])
+    ws = np.random.rand(v)
+    gold_labels = [verts[i] for i in np.argsort(ws)[::-1]]
+    gold_score = np.sort(ws)[::-1]
+    res = text_rank_output_list(graph, ws)
+    for gl, gs, (l, s) in zip(gold_labels, gold_score, res):
+        assert l == gl
+        assert math.isclose(s, gs)
 
 
 def test_output_matrix():
-    pass
+    v = random.randint(2, 10)
+    verts = [rand_str() for _ in range(v)]
+    graph = MagicMock(label2idx={v: None for v in verts})
+    ws = np.random.rand(v)
+    gold_labels = [verts[i] for i in np.argsort(ws)[::-1]]
+    gold_score = np.sort(ws)[::-1]
+    res = text_rank_output_matrix(graph, ws)
+    for gl, gs, (l, s) in zip(gold_labels, gold_score, res):
+        assert l == gl
+        assert math.isclose(s, gs)
+
+
+def random_graphs(p=None, min_vert=10, max_vert=100):
+    p = random.random() if p is None else p
+    verts = [str(i) for i in range(random.randint(min_vert, max_vert))]
+    graph = AdjacencyMatrix(verts)
+    graph2 = AdjacencyList(verts)
+    for src, tgt in combinations(verts, 2):
+        if src == tgt:
+            continue
+        if random.random() <= p:
+            graph.add_edge(src, tgt, 1)
+            graph2.add_edge(src, tgt, 1)
+            graph.add_edge(tgt, src, 1)
+            graph2.add_edge(tgt, src, 1)
+    return graph, graph2
+
+
+def test_text_rank():
+    g1, g2 = random_graphs()
+    g1_out = text_rank(g1, seed=1234)
+    g2_out = text_rank(g2, seed=1234)
+    for (g1_label, g1_score), (g2_label, g2_score) in zip(g1_out, g2_out):
+        assert g1_label == g2_label
+        math.isclose(g1_score, g2_score)

--- a/text_rank/graph.py
+++ b/text_rank/graph.py
@@ -117,7 +117,7 @@ class Graph:
         :param source: The vertex label or index of the edge source
         :param target: The vertex label or index of the edge target
         :param weight: The weight to put on the edge
-        :raises ValueError: When the source and target node are the same
+        :raises ValueError: When the source and target node are the same, when the weight is less than zero
         """
         raise NotImplementedError
 
@@ -217,7 +217,10 @@ class AdjacencyList(Graph):
         :param source: The vertex label or index of the edge source
         :param target: The vertex label or index of the edge target
         :param weight: The weight to put on the edge
+        :raises ValueError: When the source and target node are the same, when the weight is less than zero
         """
+        if weight < 0.0:
+            raise ValueError(f"Edge weight must be greater than zero, got {weight}")
         source_idx = source if isinstance(source, int) else self[source]
         target_idx = target if isinstance(target, int) else self[target]
         if source_idx == target_idx:
@@ -353,7 +356,10 @@ class AdjacencyMatrix(Graph):
         :param source: The vertex label or index of the edge source
         :param target: The vertex label or index of the edge target
         :param weight: The weight to put on the edge
+        :raises ValueError: When the source and target node are the same, when the weight is less than zero
         """
+        if weight < 0.0:
+            raise ValueError(f"Edge weight must be greater than zero, got {weight}")
         source_idx = source if isinstance(source, int) else self[source]
         target_idx = target if isinstance(target, int) else self[target]
         if source_idx == target_idx:

--- a/text_rank/text_rank.py
+++ b/text_rank/text_rank.py
@@ -62,8 +62,8 @@ def text_rank_init_list(graph: AdjacencyList, seed: Optional[int] = None) -> Tup
 
 @text_rank_init.register(AdjacencyMatrix)
 def text_rank_init_matrix(graph: AdjacencyMatrix, seed: Optional[int] = None) -> Tuple[np.ndarray, np.ndarray]:
-    np.random.seed(seed)
-    ws = np.random.rand(graph.vertex_count)
+    random.seed(seed)
+    ws = np.array([random.random() for _ in range(graph.vertex_count)])
     denom = np.reshape(np.sum(graph.adjacency_matrix, axis=1), (-1, 1))
     # If the sum off all outgoing edges of V_j is 0.0 then the incoming edge from V_j to V_i will be 0.0
     # We can use anything as the denominator and the value will still be zero
@@ -91,7 +91,7 @@ def text_rank_update(graph: Graph, ws: List[float], denom: List[float], dampenin
 def text_rank_update_list(
     graph: AdjacencyList, ws: List[float], denom: List[float], dampening: float = 0.85
 ) -> List[float]:
-    updates = [accumulate_scores(v, ws, denom) for v in graph.vertices]
+    updates = [accumulate_score(v, ws, denom) for v in graph.vertices]
     # We collect the updated scores for each node and apply them after. If we were to apply these
     # updates as they happen we would get different results than from the vectorized version used
     # in the adjacency matrix version
@@ -120,7 +120,6 @@ def text_rank_output_list(graph: AdjacencyList, ws: List[float]) -> List[Tuple[s
 
 @text_rank_output.register(AdjacencyMatrix)
 def text_rank_output_matrix(graph: AdjacencyMatrix, ws: np.ndarray) -> List[Tuple[str, float]]:
-    ws = np.reshape(ws, (-1,))
     return sorted(zip(graph.label2idx.keys(), ws), key=itemgetter(1), reverse=True)
 
 


### PR DESCRIPTION
This PR adds tests to the text rank code, fixes a bug in the AdjacencyList text rank code. It also unifies the initialization of the ws vector (only use `random.random()` so that we can set the seed and get the same results from both implementations.